### PR TITLE
docs: remove all promptfoo/eval references missed by #11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,8 +29,3 @@ test-alerts.json
 # Temporary files
 tmp/
 temp/
-
-# Promptfoo eval results
-eval-results.json
-.promptfoo/
-output/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,24 +43,13 @@ This avoids wasted effort and keeps the repo focused.
 
 ## Development Setup
 
-**Prerequisites:** Node.js 20+, an Anthropic API key.
-
 ```bash
-# 1. Fork and clone
+# Fork and clone
 git clone https://github.com/<your-username>/orca-skills.git
 cd orca-skills
-
-# 2. Install the evaluation framework
-npm install -g promptfoo
-
-# 3. Set your API key
-export ANTHROPIC_API_KEY="your-key-here"
-
-# 4. Verify everything works
-promptfoo eval --no-progress-bar
 ```
 
-This runs the Layer 1 (CI) test suite using fabricated sample data from `test-data/` — no Orca account or live credentials required. See [EVALS.md](EVALS.md) for full details on the two-layer testing approach.
+Skills are plain Markdown files under `skills/<skill-name>/SKILL.md` — no build step or runtime is required to author or modify them. Install them via the Claude Code plugin marketplace (see [README](README.md)) to try them locally.
 
 **Note:** `.mcp.json` is gitignored. Never commit API tokens or credentials.
 
@@ -75,30 +64,22 @@ This runs the Layer 1 (CI) test suite using fabricated sample data from `test-da
    git checkout -b docs/update-readme
    ```
 
-2. **Make your changes.** For new or modified skills, add or update test cases in `promptfooconfig.yaml` and sample data in `test-data/`.
+2. **Make your changes.** Edit or add `SKILL.md` files under `skills/<skill-name>/`.
 
-3. **Run the test suite locally** before pushing:
-   ```bash
-   promptfoo eval --no-progress-bar
-   ```
+3. **Keep PRs focused.** One bug fix or one new skill per PR. Do not bundle unrelated changes.
 
-4. **Keep PRs focused.** One bug fix or one new skill per PR. Do not bundle unrelated changes.
-
-5. **PR titles** should follow this format:
+4. **PR titles** should follow this format:
    - `add: orca-new-skill — one-line description`
    - `fix: orca-alert-triage — describe what was broken`
    - `docs: what was updated`
    - `refactor: what changed and why`
 
-6. **PR description** must include:
+5. **PR description** must include:
    - What changed and why
    - A link to the related issue (if applicable)
-   - Confirmation that `promptfoo eval` passes locally
-   - For new skills: a brief Layer 2 validation note (did you test with a real Orca environment?)
+   - For new skills: a brief validation note (did you test with a real Orca environment?)
 
-7. **CI must pass.** GitHub Actions runs `promptfoo eval` on every PR targeting `main`. PRs with failing CI will not be reviewed.
-
-8. **One approving review** from a maintainer is required to merge.
+6. **One approving review** from a maintainer is required to merge.
 
 ---
 
@@ -109,11 +90,6 @@ This runs the Layer 1 (CI) test suite using fabricated sample data from `test-da
 - The `description` field is used for AI trigger matching — write it as a complete sentence and include example phrases users might say.
 - Instructions should be written in clear, imperative language.
 - Each skill should do one thing well — avoid scope creep.
-
-**Test cases (`promptfooconfig.yaml`):**
-- Use `javascript` assertions to validate structure and calculations, not exact phrasing — exact string assertions are brittle.
-- All test data must be fabricated. No real account IDs, emails, alert IDs, or credentials in `test-data/`.
-- Include at least one edge case (empty array, missing field, null value).
 
 **Markdown:**
 - ATX-style headings (`##`, not underlines).

--- a/README.md
+++ b/README.md
@@ -1008,39 +1008,6 @@ COVERAGE GAPS (suggest custom discovery alerts):
 </details>
 
 
-## Testing
-
-All skills include automated evaluations using [Promptfoo](https://www.promptfoo.dev/).
-
-### Run Tests Locally
-
-```bash
-# Install Promptfoo
-npm install -g promptfoo
-
-# Set your API key
-export ANTHROPIC_API_KEY="your-key"
-
-# Run all tests
-promptfoo eval
-
-# View results
-promptfoo view
-```
-
-See [EVALS.md](EVALS.md) for detailed testing guide, including:
-- Test coverage per skill
-- Adding new test cases
-- CI/CD integration
-- Debugging failed tests
-
-**Test suite includes ~30 test cases covering:**
-- Skill triggering from natural language
-- Output format validation
-- Error handling
-- Cross-model compatibility
-- Proactive remediation behavior
-
 ## Contributing
 
 We welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.


### PR DESCRIPTION
## Summary

PR #11 removed the promptfoo test suite (`promptfooconfig.yaml`, `EVALS.md`, `test-data/`, the `eval-skills` CI workflow), but three files still referenced it:

- **`CONTRIBUTING.md`** — dev setup told contributors to `npm install -g promptfoo`, export `ANTHROPIC_API_KEY`, and run `promptfoo eval`; PR checklist required `promptfoo eval` passes; style guide had a whole "Test cases (`promptfooconfig.yaml`)" section
- **`README.md`** — a full "Testing" section walking users through `promptfoo eval` with a broken link to deleted `EVALS.md`
- **`.gitignore`** — `eval-results.json`, `.promptfoo/`, `output/` entries for files that can no longer exist

All three are now stripped.

## Files changed

| File | Change |
|---|---|
| `CONTRIBUTING.md` | -32 / +8 — dev setup simplified, PR steps renumbered, test-cases style subsection removed |
| `README.md` | -33 / 0 — entire `## Testing` section deleted |
| `.gitignore` | -5 / 0 — Promptfoo block removed |

## Verification

```bash
git ls-files | xargs grep -l -i -E 'promptfoo|EVALS\.md|test-data/|ANTHROPIC_API_KEY|eval-skills|TESTING-REFACTOR'
# (no output — clean)
```

## Test plan

- [x] Repo-wide grep for `promptfoo|EVALS|test-data|ANTHROPIC_API_KEY|eval-skills` returns nothing in tracked files
- [x] `CONTRIBUTING.md`, `README.md` render cleanly on GitHub
- [x] No links pointing to deleted files (`EVALS.md`, `promptfooconfig.yaml`, `test-data/`)