### PR TITLE
add: orca-supply-chain-exposure, orca-cve-blast-radius, orca-account-health

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@
 | [`orca-investigate`](#orca-investigate) | "What happened, who did it, and how far did they get?" |
 | [`orca-cloud-cost-optimizer`](#orca-cloud-cost-optimizer) | "Where are we overspending and what should we fix first?" |
 | [`orca-custom-framework`](#orca-custom-framework) | "How do I create a custom compliance framework tailored to my needs?" |
+| [`orca-supply-chain-exposure`](skills/orca-supply-chain-exposure/) | "From this list of suspect packages, which are we actually running and where?" |
+| [`orca-cve-blast-radius`](skills/orca-cve-blast-radius/) | "This CVE just dropped — which assets are actually at risk?" |
+| [`orca-account-health`](skills/orca-account-health/) | "Is every account connected, synced, and fully scanned?" |
 
 ### Recommended Workflows
 
@@ -52,6 +55,10 @@
 > **Incident response:** Investigate → Identity review → Asset profile → Contain and remediate
 >
 > **Custom compliance:** Custom framework → Compliance gaps → Impact analysis → Remediate
+>
+> **Reactive (advisory landed):** Supply chain exposure → CVE blast radius → Impact analysis → Fix
+>
+> **Pre-audit / pre-investigation:** Account health → Compliance gaps / Investigate (trust the data first)
 
 ## Installation
 

--- a/skills/orca-account-health/SKILL.md
+++ b/skills/orca-account-health/SKILL.md
@@ -1,0 +1,335 @@
+---
+name: orca-account-health
+description: Cloud account coverage and sync-health audit — lists every connected cloud account, sync status, scanner deployment, integration health, and flags blind spots before any audit, investigation, or security review. Use when user asks about coverage, account health, sync status, scanner deployment, "are we monitoring X", or "do we have full coverage" (e.g., "account health", "are all accounts connected", "is everything synced", "coverage audit").
+trigger: When user asks about Orca tenant coverage, account connectivity, integration status, scanner deployment, sync freshness, or wants confidence the data behind an investigation/audit is complete and recent. Also pre-audit ("prove we have full coverage") and pre-investigation ("is the data fresh?").
+---
+
+# Orca Account Health Skill
+
+Answers the question: **"Is every account connected, recently synced, and fully scanned — so we can trust the data we're about to act on?"**
+
+Blind spots in account coverage produce blind spots in every other skill: if `prod-eu-west` last synced 48 hours ago, the alerts you triage are stale. This skill audits the foundation.
+
+## Usage
+
+```
+/orca-account-health
+/orca-account-health aws
+/orca-account-health degraded
+```
+
+Or natural language:
+- "are all accounts connected?"
+- "is everything synced?"
+- "coverage audit before the audit"
+- "any blind spots?"
+- "show me account health"
+
+## Processing Logic
+
+### Step 1: Determine Scope
+
+Parse the input:
+- **No arg**: full inventory across all clouds.
+- **Provider arg** (`aws`, `gcp`, `azure`, `kubernetes`, `oci`): filter to one cloud.
+- **Status arg** (`degraded`, `offline`, `healthy`): filter by health.
+
+### Step 2: Pull integration configs (single call)
+
+```
+get_integration_configs_data:
+```
+
+This returns every configured integration / source: cloud accounts, log sources (CloudTrail, Azure Monitor, etc.), Kubernetes clusters, and their extraction settings. Parse out:
+- Source type and provider
+- Connection state
+- Last successful run / sync timestamp
+- Any error messages or degraded indicators
+
+### Step 3: Cross-check coverage with discovery (parallel)
+
+In parallel with Step 2, run two `discovery_search` queries to spot-check that data is *actually* flowing — not just that the connection exists:
+
+**Query A: Asset freshness per account**
+```
+discovery_search:
+  search_phrase: "assets grouped by cloud account"
+  limit: 50
+```
+
+**Query B: Recent CDR event flow** (confirms log ingestion, not just inventory)
+```
+discovery_search:
+  search_phrase: "cloud audit events in the last 24 hours grouped by account"
+  limit: 50
+```
+
+If an account appears in `get_integration_configs_data` but returns **zero assets** or **zero recent CDR events**, that's a covert blind spot even though the integration reports "connected."
+
+### Step 4: Compute per-account health
+
+For each account, derive a health verdict:
+
+| State | Definition |
+|---|---|
+| **Healthy** | Connected, synced in last 24h, scanner deployed, ≥1 recent CDR event |
+| **Sync Lag** | Connected, last sync 24–72h ago, scanner deployed |
+| **Stale** | Connected, last sync > 72h ago |
+| **Degraded** | Connection error reported, OR scanner missing, OR no CDR events in 72h |
+| **Offline** | Never synced, OR connection broken |
+| **Recently Added** | Onboarded in the last 7 days (verify onboarding finished) |
+
+### Step 5: Detect specific blind-spot patterns
+
+Flag these patterns explicitly — they're the ones that bite during audits or investigations:
+
+1. **Account is connected but produces no assets** → onboarding likely incomplete.
+2. **Account is connected, has assets, but no CDR events in 24h** → audit log integration broken (CloudTrail / Azure Monitor / GCP Audit Logs misrouted).
+3. **Scanner deployed but stuck on a stale scan** → SideScanning or workload scanner needs restart.
+4. **New account added < 7 days ago, no successful sync yet** → onboarding incomplete or failed silently.
+5. **Provider drift** — account listed in one cloud's console but missing from Orca.
+
+## Proactive Behavior
+
+**This skill is diagnostic, not remediation-heavy** — but it should still surface the next step:
+
+1. **Identify the worst blind spot** and recommend a specific fix:
+   - "Reconnect `prod-eu-west` — last sync 48h ago, no CDR events. Open Orca Console → Cloud Accounts → Reconnect."
+2. **For onboarding failures**, link to the docs:
+   - `/orca-account-health` should reference `documentation_search` for "onboarding troubleshooting" if user asks "how do I fix it".
+3. **Pre-audit framing**: if the user said "before the audit", explicitly say whether they can proceed or need to wait for re-sync.
+
+## Output Format
+
+### Layer 1: Coverage Dashboard
+
+```
+═══════════════════════════════════════════════════════════════════
+ACCOUNT HEALTH — Cloud Coverage Audit
+<date> | <scope>
+═══════════════════════════════════════════════════════════════════
+
+VERDICT: <one-liner — "Full coverage, all green" / "1 offline, 2 sync lag, action needed">
+
+┌─────────────────────────────────────────────────────────────────┐
+│  TOTAL ACCOUNTS    <N>                                          │
+│  HEALTHY           <N>                                          │
+│  SYNC LAG          <N> (24-72h since last sync)                 │
+│  STALE             <N> (> 72h since last sync)                  │
+│  DEGRADED          <N> (errors / scanner gap / no CDR)          │
+│  OFFLINE           <N> (broken / never synced)                  │
+│  RECENTLY ADDED    <N> (onboarded < 7d, verify completion)      │
+│  BLIND SPOTS       <N> (connected but no data flowing)          │
+└─────────────────────────────────────────────────────────────────┘
+
+ACCOUNT STATUS:
+  Account              Provider   Last Sync     Scanner   CDR    Status
+  ────────────────────────────────────────────────────────────────────────
+  <account-1>          AWS        2 min ago     YES       OK     Healthy
+  <account-2>          AWS        26 hours ago  YES       OK     Sync Lag
+  <account-3>          Azure      Never         NO        —      Offline
+  <account-4>          GCP        2h ago        YES       NO     Degraded
+  ...
+
+BLIND SPOTS (immediate attention):
+  [!] <account> — <specific issue>
+      Impact: <what's invisible because of this gap>
+      Fix: <specific action>
+
+  [!] <account> — ...
+
+RECOMMENDED ACTION:
+  Reconnect <account> first — <reason>.
+  After reconnect, re-run any pending investigation or audit.
+
+═══════════════════════════════════════════════════════════════════
+Or drill down: degraded | offline | sync-lag | recently-added |
+by-provider | full
+═══════════════════════════════════════════════════════════════════
+```
+
+### Layer 2: Drill-Downs
+
+#### "degraded" — Accounts with active problems
+
+```
+───────────────────────────────────────────────────────────────────
+DEGRADED ACCOUNTS — Active Issues
+───────────────────────────────────────────────────────────────────
+
+  [!] <account> (<provider>)
+      Connection: <state>
+      Last sync: <time>
+      Scanner: <deployed / missing / stuck>
+      CDR ingestion: <events in 24h or "none">
+      Error: <reported error message>
+      Impact: <what's invisible — e.g. "any investigation in this
+              account is missing the last 6h of CDR data">
+      Fix: <specific action — link to documentation_search if needed>
+
+  [!] <account> — ...
+
+───────────────────────────────────────────────────────────────────
+```
+
+#### "offline" — Broken or never-synced accounts
+
+```
+───────────────────────────────────────────────────────────────────
+OFFLINE ACCOUNTS
+───────────────────────────────────────────────────────────────────
+
+These accounts are configured but Orca has no data:
+
+  [X] <account> (<provider>)
+      Last successful sync: <date or NEVER>
+      Connection error: <message>
+      Likely cause: <inferred — e.g. revoked role, deleted trust policy>
+      Fix path: <action>
+
+───────────────────────────────────────────────────────────────────
+```
+
+#### "sync-lag" — Accounts behind on sync
+
+```
+───────────────────────────────────────────────────────────────────
+SYNC LAG — 24-72h Behind
+───────────────────────────────────────────────────────────────────
+
+  <account> (<provider>) — last sync <time> ago
+    Why it matters: <e.g. "alerts triaged here may be missing the
+                    last day of activity">
+
+  ...
+
+If urgency is high (audit, investigation), force a re-sync:
+  Orca Console → Cloud Accounts → <account> → Sync Now
+───────────────────────────────────────────────────────────────────
+```
+
+#### "recently-added" — New accounts (verify onboarding)
+
+```
+───────────────────────────────────────────────────────────────────
+RECENTLY ADDED ACCOUNTS — Verify Onboarding
+───────────────────────────────────────────────────────────────────
+
+  <account> (<provider>) — added <N> days ago
+    First sync: <success / pending / failed>
+    Assets discovered: <N>
+    Scanner deployed: <Y/N>
+    CDR ingestion: <active / pending>
+    Onboarding status: <complete / pending / failed>
+
+───────────────────────────────────────────────────────────────────
+```
+
+#### "by-provider" — Coverage split by cloud
+
+```
+───────────────────────────────────────────────────────────────────
+COVERAGE BY PROVIDER
+───────────────────────────────────────────────────────────────────
+
+  Provider     Connected   Healthy   Issues
+  ───────────────────────────────────────────
+  AWS          <N>         <N>       <N>
+  Azure        <N>         <N>       <N>
+  GCP          <N>         <N>       <N>
+  Kubernetes   <N>         <N>       <N>
+  OCI          <N>         <N>       <N>
+
+───────────────────────────────────────────────────────────────────
+```
+
+#### "full"
+Show all sections in order.
+
+## Edge Cases
+
+### No Accounts Configured
+```
+⚠ No cloud accounts configured in Orca.
+
+To get started:
+  Orca Console → Cloud Accounts → Add Account
+  Choose: AWS / Azure / GCP / Kubernetes / OCI
+
+After onboarding, re-run /orca-account-health to verify coverage.
+```
+
+### All Accounts Healthy
+```
+✅ All <N> accounts healthy.
+
+  • All connections active
+  • All accounts synced within the last hour
+  • All scanners deployed
+  • CDR ingestion active across all accounts
+
+You're clear to proceed with audit / investigation / review.
+```
+
+### Coverage Mismatch (account in cloud console but not in Orca)
+```
+⚠ Provider-side accounts NOT in Orca:
+
+This skill can only see what's configured in Orca. If your AWS Org has
+30 accounts but Orca has 25, the other 5 are invisible here.
+
+To verify completeness:
+  • Compare Orca account list against AWS Organizations / Azure Tenants /
+    GCP Organization root.
+  • Use /orca-account-health to confirm Orca's view; cross-check
+    externally for accounts that never made it to Orca.
+```
+
+### "Connected but Empty"
+```
+⚠ <account> reports "connected" but Orca has zero assets and zero events.
+
+This is the worst kind of blind spot — the integration looks healthy in
+the dashboard but no data is actually flowing.
+
+Likely causes:
+  • IAM role attached but policy missing read permissions
+  • Cross-account trust set up but external ID mismatch
+  • Newly added account, scan not yet started
+  • Region scope of the integration excludes the account's resources
+
+Fix path:
+  Orca Console → Cloud Accounts → <account> → Verify Permissions
+```
+
+## MCP Tools Used
+
+### Primary Tools
+
+| Tool | Purpose | Parameter |
+|------|---------|-----------|
+| `get_integration_configs_data` | All connected sources, state, last sync | (none) |
+| `discovery_search` | Cross-check assets and CDR flow per account | `search_phrase` (NL), `limit` |
+
+### Secondary Tools
+
+| Tool | Purpose | When |
+|------|---------|------|
+| `get_cdr_events_grouped_by_event_name` | Deeper CDR ingestion check | When `discovery_search` says "no CDR events" — confirm |
+| `documentation_search` | Onboarding/troubleshooting docs | When user asks "how do I fix it" |
+| `get_business_units_data` | Map accounts to ownership for assignment | When user wants to route fixes to a team |
+
+### Parameter Notes
+
+- `get_integration_configs_data` takes **no parameters** — it's a full dump of configured sources. Filter client-side.
+- `discovery_search` for `"cloud audit events in the last 24 hours grouped by account"` is the best signal that audit log ingestion is actually working — connection state alone is insufficient.
+- `discovery_search` is capped at 50 results; for tenants with many accounts, narrow with `"... in account <id>"`.
+
+## Implementation Notes
+
+1. **Two-source verification is the differentiator.** `get_integration_configs_data` alone says "connected"; the discovery cross-check says "data is actually flowing." A "connected but empty" account is the worst blind spot and only the cross-check catches it.
+2. **Categorize the freshness, don't dump timestamps.** Users need "Healthy / Sync Lag / Stale / Degraded / Offline" buckets, not raw "last_sync_at" values.
+3. **Always state the impact of each gap.** Don't say "prod-eu-west has sync lag" — say "any alert triage in prod-eu-west is missing the last day's data". Connect the gap to the next action.
+4. **Pre-audit / pre-investigation framing matters.** If the user invoked this before another skill ("before /orca-investigate"), end with an explicit "you can proceed" or "wait for re-sync" verdict.
+5. **External coverage drift** (accounts in AWS Org but not in Orca) is out of scope for this skill — flag it in the edge case and recommend manual cross-check rather than pretend the MCP can detect it.
+6. **Link to other skills**: this skill is a prerequisite for trusting the output of `/orca-morning-briefing`, `/orca-investigate`, `/orca-compliance-gap`, and `/orca-cve-blast-radius`. Mention this when appropriate.

--- a/skills/orca-cve-blast-radius/SKILL.md
+++ b/skills/orca-cve-blast-radius/SKILL.md
@@ -1,0 +1,322 @@
+---
+name: orca-cve-blast-radius
+description: CVE blast-radius analysis — given a single CVE-ID, find every affected asset across all accounts, rank by real exposure (internet-facing, attack-path participant, crown jewel) instead of static CVSS. Use when user asks about a specific CVE's environmental impact (e.g., "blast radius of CVE-2024-1234", "where are we affected by Log4Shell", "which assets have CVE-2021-44228", "who is exposed to CVE-XXXX").
+trigger: When user names a CVE-ID (CVE-YYYY-NNNNN format) and asks about exposure, blast radius, affected assets, or "where are we hit by". Also when an MDR/news/advisory mentions a single CVE the user wants to react to.
+---
+
+# Orca CVE Blast-Radius Skill
+
+Answers the question: **"This CVE just dropped — which of our assets are actually at risk, ranked by real exposure?"**
+
+Static CVSS doesn't tell you which workloads matter. This skill takes a CVE-ID, finds every affected asset across all accounts, and ranks them by **runtime exposure context** — internet-facing, attack-path participation, crown jewel status, and existing related alerts.
+
+## Usage
+
+```
+/orca-cve-blast-radius CVE-2021-44228
+/orca-cve-blast-radius CVE-2024-1234
+/orca-cve-blast-radius CVE-2024-3094 prod
+```
+
+Or natural language:
+- "blast radius of CVE-2024-1234"
+- "where are we affected by Log4Shell?"
+- "which assets have CVE-2021-44228?"
+- "show me CVE-2024-3094 across all accounts"
+
+## Processing Logic
+
+### Step 1: Parse the CVE-ID
+
+Extract a single CVE-ID in `CVE-YYYY-NNNNN` form. If the user provided a name (e.g. "Log4Shell", "xz backdoor", "Spring4Shell"), map to the canonical CVE-ID first using a `discovery_search` query like `"<name> CVE"`. If the mapping is ambiguous, list candidates and ask the user to pick.
+
+Optional scope arg: `prod`, `staging`, `account <id>`. Default: all accounts.
+
+### Step 2: Find every affected asset (parallel)
+
+Run all three queries in parallel:
+
+**Query 1: Asset hits by CVE-ID**
+```
+discovery_search:
+  search_phrase: "assets with <CVE-ID>"
+  limit: 50
+```
+
+**Query 2: Critical exposure hits**
+```
+discovery_search:
+  search_phrase: "internet facing assets with <CVE-ID>"
+  limit: 50
+```
+
+**Query 3: Active alert hits** (catches assets where Orca raised the CVE as an alert)
+```
+discovery_search:
+  search_phrase: "open alerts for <CVE-ID>"
+  limit: 50
+```
+
+De-duplicate by `asset_id` / `group_unique_id` after the three queries return. The intersection (assets in all three sets) is the highest priority.
+
+### Step 3: Enrich top affected assets (parallel)
+
+Take the top 10 affected assets (prioritized by: internet-facing first → then by alert count → then by asset name). Per asset, in parallel:
+
+```
+get_asset_by_id:
+  asset_id: <UUID>
+```
+```
+get_asset_related_alerts_summary:
+  asset_id: <UUID>
+```
+```
+get_asset_related_attack_paths_summary:
+  asset_id: <UUID>
+```
+```
+get_asset_crown_jewel_info:
+  group_unique_id: <group_unique_id>
+```
+
+This yields the runtime context: exposure, attack-path participation, crown jewel, and existing alerts.
+
+### Step 4: Rank by real exposure
+
+Score each affected asset on a 0-100 scale:
+
+| Signal | Points |
+|---|---|
+| Internet-facing | +30 |
+| Participates in ≥1 attack path | +25 |
+| Crown jewel | +20 |
+| ≥1 other CRITICAL alert | +15 |
+| Prod environment tag | +10 |
+
+**Ranking tiers** (after scoring):
+- **CRITICAL (≥ 60)**: internet-facing + attack path + (crown jewel OR other critical alerts). Patch now.
+- **HIGH (40–59)**: internet-facing OR attack-path participant. Patch this sprint.
+- **MEDIUM (20–39)**: vulnerable but not exposed externally. Patch in normal cycle.
+- **LOW (< 20)**: vulnerable but isolated. Patch on next dependency bump.
+
+### Step 5: Map attack paths through the CVE
+
+For CRITICAL-tier assets, traverse attack paths starting from the CVE-vulnerable asset:
+
+```
+get_asset_related_attack_paths:
+  asset_id: <UUID>
+```
+
+Show the kill chain: CVE → exploit → pivot → crown jewel.
+
+## Proactive Remediation Behavior
+
+**CRITICAL: Never leave the user with just data.** After the report:
+
+1. **Suggest action** — "Patch `<asset>` first because it's internet-facing + participates in 2 attack paths."
+2. **Offer remediation format** — "I can generate the patch manifest. Choose format: terraform | helm | ansible | cli | dockerfile-patch | k8s-patch | instructions."
+3. **For CRITICAL-tier assets**, auto-suggest opening an incident ticket and snoozing other noise.
+
+When user picks a format:
+- Generate the upgrade or mitigation config
+- Write to `cve-fix-<cve-id>-<asset>.<ext>`
+- Include the verification command
+- Suggest the next asset to patch
+
+## Output Format
+
+### Layer 1: Blast Radius Dashboard
+
+```
+═══════════════════════════════════════════════════════════════════
+CVE BLAST RADIUS — <CVE-ID>
+<CVE name if known, e.g. Log4Shell> | <CVSS score> | <fix available?>
+<date> | <scope>
+═══════════════════════════════════════════════════════════════════
+
+VERDICT: <one-liner — "12 affected, 3 critical, patch within 24h">
+
+┌─────────────────────────────────────────────────────────────────┐
+│  TOTAL AFFECTED        <N> assets                               │
+│  CRITICAL TIER         <N> (internet-facing + reachable target) │
+│  HIGH TIER             <N> (exposed OR attack-path participant) │
+│  MEDIUM TIER           <N> (vulnerable, internal-only)          │
+│  LOW TIER              <N> (isolated)                           │
+│  CROWN JEWELS AFFECTED <N>                                      │
+│  ATTACK PATHS THROUGH  <N>                                      │
+│  ACCOUNTS AFFECTED     <N>                                      │
+└─────────────────────────────────────────────────────────────────┘
+
+CRITICAL TIER (patch within 24h):
+  [1] <asset> (<type>) in <account> — score <X>
+      Internet-facing: YES | Attack paths: <N> | Crown jewel: YES/NO
+      Other criticals: <N> | Env: prod
+      Exploit path: <CVE> → <pivot> → <target>
+
+  [2] <asset> — score <X>
+      ...
+
+RECOMMENDED ACTION:
+  Patch <top asset> first — <reason>.
+  I can generate the patch right now.
+
+  What format? terraform | helm | ansible | cli | dockerfile-patch |
+  k8s-patch | instructions | pulumi
+
+═══════════════════════════════════════════════════════════════════
+Or drill down: critical | high | medium | low | attack-paths |
+by-account | full
+═══════════════════════════════════════════════════════════════════
+```
+
+### Layer 2: Drill-Downs
+
+#### "critical" — Critical-tier assets
+
+```
+───────────────────────────────────────────────────────────────────
+CRITICAL TIER — Patch Within 24h
+───────────────────────────────────────────────────────────────────
+
+  [!] <asset> (<type>) in <account>
+      Score: <X>/100
+      Internet-facing: YES | Public IP: <ip>
+      Attack paths: <N> kill chains through this asset
+      Crown jewel: YES (data classification: <X>)
+      Other critical alerts: <N>
+      Related Orca alert: <alert-id> — <title>
+      Fix: upgrade <package> to <safe-version>
+      OR mitigation: <workaround if known>
+
+  [!] <asset> — ...
+
+───────────────────────────────────────────────────────────────────
+```
+
+#### "attack-paths" — Kill chains through the CVE
+
+```
+───────────────────────────────────────────────────────────────────
+ATTACK PATHS — CVE as Entry Point
+───────────────────────────────────────────────────────────────────
+
+  [1] Score: <X.X>
+      Entry: <vulnerable asset> (public IP: <ip>)
+        → Exploit: <CVE-ID> (<exploit availability>)
+        → Pivot: <internal asset>
+        → Target: <crown jewel> (<why it matters>)
+      Break chain: patch <package> on <entry asset>
+
+  [2] Score: <X.X>
+      Entry: <vulnerable asset>
+        → ...
+
+TOTAL PATHS THROUGH <CVE-ID>: <N>
+Crown jewels reachable: <N>
+
+───────────────────────────────────────────────────────────────────
+```
+
+#### "by-account" — Affected count by account
+
+```
+───────────────────────────────────────────────────────────────────
+AFFECTED ASSETS BY ACCOUNT
+───────────────────────────────────────────────────────────────────
+
+  Account              Total   Critical   High   Medium   Low
+  ──────────────────────────────────────────────────────────────
+  <account-1>          <N>     <N>        <N>    <N>      <N>
+  <account-2>          <N>     <N>        <N>    <N>      <N>
+  ...
+
+WORST ACCOUNT: <account> — <why>
+
+───────────────────────────────────────────────────────────────────
+```
+
+#### "high" / "medium" / "low"
+Same table-per-tier layout as "critical" with reduced enrichment.
+
+#### "full"
+Show all sections in order.
+
+## Edge Cases
+
+### CVE Not Found in Any Asset
+```
+✅ No assets affected by <CVE-ID> in the monitored environment.
+
+Caveats:
+  • Verify Orca scanner coverage with /orca-account-health
+  • The CVE may be too new for Orca's vulnerability database — check the
+    Orca UI → Vulnerabilities for the latest sync time
+  • Some vulnerabilities only surface after a workload runs — recently
+    deployed assets may not yet be flagged
+```
+
+### Invalid or Unrecognized CVE-ID
+```
+⚠ <input> doesn't match a known CVE.
+
+Did you mean one of these?
+  • CVE-YYYY-XXXXX — <title>
+  • CVE-YYYY-XXXXX — <title>
+
+Or provide the canonical ID in CVE-YYYY-NNNNN form.
+```
+
+### Massive Blast Radius (> 50 hits per query)
+```
+⚠ <CVE-ID> affects more than 50 assets — discovery_search is capped at 50.
+
+Showing top 50 by exposure score. For the full inventory:
+  Open the app_url in the discovery_search response, OR
+  Re-run with a narrower scope: /orca-cve-blast-radius <CVE> account <id>
+```
+
+### CVE Affects Multiple Packages
+```
+<CVE-ID> spans multiple packages: <name1>, <name2>.
+Showing combined exposure. Drill into a single package with:
+  /orca-supply-chain-exposure <package>
+```
+
+## MCP Tools Used
+
+### Primary Tools
+
+| Tool | Purpose | Parameter |
+|------|---------|-----------|
+| `discovery_search` | Find assets affected by a CVE | `search_phrase` (NL), `limit` |
+| `get_asset_by_id` | Asset metadata + env tag | `asset_id` (UUID) |
+| `get_asset_related_alerts_summary` | Existing alerts (incl. the CVE alert itself) | `asset_id` (UUID) |
+| `get_asset_related_attack_paths_summary` | Attack-path participation count | `asset_id` (UUID) |
+| `get_asset_crown_jewel_info` | Crown jewel status | `group_unique_id` |
+
+### Secondary Tools
+
+| Tool | Purpose | When |
+|------|---------|------|
+| `get_asset_related_attack_paths` | Full kill-chain detail | "attack-paths" drill-down |
+| `get_attack_path` | Single attack-path expansion | When drilling into one chain |
+| `get_alert` | Full detail on the CVE alert | When user wants alert text/IoC |
+| `get_alerts_with_similar_alert_type` | Other CVE alerts of same type | Pattern-matching across assets |
+
+### Parameter Notes
+
+- The three `discovery_search` queries (asset-with-CVE, internet-facing-with-CVE, open-alerts-for-CVE) hit different indexes — running all three is what catches assets that one query alone misses.
+- `discovery_search` is **capped at 50 results** — surface `app_url` when truncated and recommend account-level scoping.
+- `get_asset_related_attack_paths_summary` returns counts only; use `get_asset_related_attack_paths` for full kill-chain.
+- CVE name → CVE-ID mapping (e.g. "Log4Shell" → CVE-2021-44228) is not built into the MCP; a `discovery_search` for `"<name> CVE"` is the usable workaround.
+
+## Implementation Notes
+
+1. **The three-query fan-out in Step 2 is non-negotiable** — each surfaces different assets. De-duplicate after, not before.
+2. **Real exposure beats CVSS.** A CVSS 10.0 on an isolated dev box matters less than a CVSS 7.5 on an internet-facing crown jewel. The scoring rubric in Step 4 enforces this.
+3. **Cap enrichment to top 10 assets** — full per-asset enrichment is 4 tool calls × N assets. With many affected assets, this balloons fast.
+4. **CRITICAL tier should always have an exploit path shown**, even if it's a one-hop ("CVE → asset → exposed port"). The kill chain framing is what makes the urgency clear.
+5. **Link to other skills**: suggest `/orca-impact-analysis` for fix consequences, `/orca-alert-triage <alert-id>` for the related Orca CVE alert, `/orca-supply-chain-exposure <package>` for the package-level view, `/orca-asset-profile <asset>` for full asset context.
+6. **The CVE may not be in Orca's DB yet** for very fresh disclosures — surface the caveat in the "Not Found" edge case and don't claim a clean bill of health prematurely.

--- a/skills/orca-supply-chain-exposure/SKILL.md
+++ b/skills/orca-supply-chain-exposure/SKILL.md
@@ -291,4 +291,3 @@ Manual verification needed in Orca UI → Asset → SBOM.
 3. **"Below Range" is a real status, not a non-finding** — call it out explicitly so the user sees that the check ran and the asset is verified safe.
 4. **Crown jewel + internet-facing flag** turns a generic "vulnerable" hit into a priority-1 incident. Always enrich confirmed exposures with these two fields.
 5. **Link to other skills**: suggest `/orca-impact-analysis` for fix consequences, `/orca-alert-triage` for any related CVE alert, `/orca-account-health` if "not found" results need a coverage sanity-check.
-6. **Optional research escalation**: if connected to the SingleStore observations DB (`mcp__singlestore-observations__execute_sql`), use the `observations_non_inventory` table for cross-tenant package searches. This is a research-mode capability, not a customer-facing flow.

--- a/skills/orca-supply-chain-exposure/SKILL.md
+++ b/skills/orca-supply-chain-exposure/SKILL.md
@@ -1,0 +1,294 @@
+---
+name: orca-supply-chain-exposure
+description: Supply chain exposure check — given a list of suspect packages (e.g. an MDR advisory like the @antv/* npm campaign), find which versions are deployed across the environment, which match the vulnerable range, and which assets carry them. Use when user asks about supply chain risk, package exposure, IOC package check, malicious package, or "are we running X" (e.g., "are we exposed to the @antv attack", "any assets with left-pad", "check these npm packages", "supply chain check").
+trigger: When user provides a list of packages (with or without suspected versions) and wants to know whether any are running in the environment, or references a published supply-chain campaign / IOC list / dependency advisory and asks "are we exposed".
+---
+
+# Orca Supply Chain Exposure Skill
+
+Answers the question: **"From this list of suspect packages, which are we actually running, where, and at what version?"**
+
+Replaces a manual sweep of inventory + SBOM queries with a single parallel check. Optimized for the moment after an MDR / vendor / news advisory lands and the team needs an exposure answer in minutes.
+
+## Usage
+
+```
+/orca-supply-chain-exposure @antv/util @antv/g2 @antv/g6
+/orca-supply-chain-exposure log4j-core 2.14.1
+/orca-supply-chain-exposure xz-utils 5.6.0,5.6.1
+```
+
+Or natural language:
+- "are we exposed to the @antv npm attack?"
+- "check these packages: react-devtools 4.28.0, axios 0.21.0"
+- "any assets with xz-utils 5.6.x?"
+- "supply chain check on this IOC list"
+
+The user may paste a bullet list, a comma-separated list, or a table. Parse it.
+
+## Processing Logic
+
+### Step 1: Parse the package list
+
+Build a normalized list of `(package_name, suspected_versions[])`. If the user only gave package names with no versions, treat **any version found in the environment as a positive hit** and rely on Orca's CVE data to confirm vulnerability.
+
+### Step 2: Run parallel exposure queries
+
+For each package, run two queries in parallel:
+
+**Query A: Direct inventory lookup**
+```
+discovery_search:
+  search_phrase: "assets with package <name>"
+  limit: 50
+```
+
+**Query B: CVE-driven lookup** (catches assets where Orca already flags the package as vulnerable)
+```
+discovery_search:
+  search_phrase: "assets with vulnerable <name> package"
+  limit: 50
+```
+
+**Batching rule:** Run all packages' Query A and Query B in parallel — one tool-call batch per package isn't enough, batch *across* packages. For 20 packages, that's 40 parallel `discovery_search` calls in one message.
+
+### Step 3: Match version ranges
+
+For each asset returned, extract the installed version from the discovery_search response and compare against the user's suspected version list:
+
+- **Vulnerable Match**: installed version is in the suspected range.
+- **Below Range**: installed version is older than the vulnerable range (not affected).
+- **Above Range**: installed version is newer (patched or unrelated).
+- **Unknown Version**: discovery_search didn't return a version — flag and recommend a manual SBOM check in Orca UI.
+
+### Step 4: Enrich confirmed exposures
+
+For assets with **Vulnerable Match** only (top 5 by environment importance), run in parallel:
+
+```
+get_asset_by_id:
+  asset_id: <UUID>
+```
+```
+get_asset_related_alerts_summary:
+  asset_id: <UUID>
+```
+```
+get_asset_crown_jewel_info:
+  group_unique_id: <group_unique_id>
+```
+
+This adds prod/non-prod tag, exposure status, related CVEs Orca already raised, and crown-jewel status.
+
+### Step 5: Build the exposure table
+
+Output is the table the on-call team needs to paste into a ticket or status update.
+
+## Proactive Remediation Behavior
+
+**CRITICAL: Never leave the user with just data.** After the exposure table:
+
+1. **Suggest the next action** — "Patch `<package>` on `<asset>` first because it's prod + internet-facing."
+2. **Offer remediation format selection** — "I can generate the upgrade or removal manifest. Choose format: terraform | helm | ansible | cli | instructions | dockerfile-patch."
+3. **For confirmed exposure on prod assets**, auto-suggest snoozing alerts and opening an incident ticket.
+
+When the user picks a format:
+- Generate the upgrade / pin / removal config
+- Write to `supplychain-fix-<package>.<ext>`
+- Include the verification command (`npm ls <package>`, `pip show <package>`, etc.)
+- Suggest the next package to fix
+
+## Output Format
+
+### Layer 1: Exposure Table
+
+```
+═══════════════════════════════════════════════════════════════════
+SUPPLY CHAIN EXPOSURE CHECK
+<date> | <N> packages checked
+═══════════════════════════════════════════════════════════════════
+
+VERDICT: <one-liner — "1 confirmed exposure" / "no matches" / "3 vulnerable">
+
+┌─────────────────────────────────────────────────────────────────┐
+│  PACKAGES CHECKED       <N>                                     │
+│  CONFIRMED VULNERABLE   <N>                                     │
+│  BELOW RANGE            <N>                                     │
+│  NOT FOUND              <N>                                     │
+│  ASSETS AFFECTED        <N> (<M> prod, <K> non-prod)            │
+│  CROWN JEWELS AFFECTED  <N>                                     │
+└─────────────────────────────────────────────────────────────────┘
+
+EXPOSURE TABLE:
+
+  Package              Version in Env   Vulnerable Range   Status         Assets
+  ───────────────────────────────────────────────────────────────────────────────
+  <name>               <ver>            <range>            VULNERABLE     <count>
+  <name>               <ver>            <range>            Below Range    <count>
+  <name>               —                <range>            Not Found      0
+  ...
+
+CONFIRMED EXPOSURES (act on these now):
+  [!] <package>@<version> on <asset> (<type>, <prod/non-prod>)
+      Crown jewel: YES/NO | Internet-facing: YES/NO | Related alerts: <N>
+      Fix: upgrade to <safe version> OR remove if unused
+
+RECOMMENDED ACTION:
+  Top priority: patch <package> on <asset> — <reason>.
+  I can generate the fix right now.
+
+  What format? terraform | helm | ansible | cli | dockerfile-patch |
+  instructions | pulumi
+
+═══════════════════════════════════════════════════════════════════
+Or drill down: confirmed | unknown-version | not-found | by-asset | full
+═══════════════════════════════════════════════════════════════════
+```
+
+### Layer 2: Drill-Downs
+
+#### "confirmed" — Confirmed vulnerable assets
+
+```
+───────────────────────────────────────────────────────────────────
+CONFIRMED EXPOSURES
+───────────────────────────────────────────────────────────────────
+
+  [!] <asset> (<type>) in <account>
+      Package: <name>@<version>
+      Vulnerable range: <range>
+      Environment: <prod/staging/dev tag>
+      Internet-facing: YES/NO
+      Crown jewel: YES/NO
+      Related Orca alerts: <N> (top: <alert title>)
+      Upgrade path: <name>@<safe-version>
+
+  [!] <asset> — ...
+
+───────────────────────────────────────────────────────────────────
+```
+
+#### "unknown-version" — Assets where the version couldn't be determined
+
+```
+───────────────────────────────────────────────────────────────────
+UNKNOWN VERSIONS — Manual SBOM Check Required
+───────────────────────────────────────────────────────────────────
+
+These assets have the package installed, but Orca's response didn't
+include a parseable version. Verify in Orca UI → Asset → SBOM:
+
+  <asset> — <package>
+  <asset> — <package>
+  ...
+
+───────────────────────────────────────────────────────────────────
+```
+
+#### "not-found" — Packages not present in the environment
+
+```
+───────────────────────────────────────────────────────────────────
+NOT FOUND IN ENVIRONMENT
+───────────────────────────────────────────────────────────────────
+
+The following packages were not found on any monitored asset:
+  • <package> (suspected versions: <range>)
+  • <package>
+  ...
+
+Caveat: a "not found" result means Orca's inventory has no match.
+Verify scanner coverage with /orca-account-health if accounts may
+be missing.
+
+───────────────────────────────────────────────────────────────────
+```
+
+#### "by-asset" — Grouped by asset (useful for ticket assignment)
+
+```
+───────────────────────────────────────────────────────────────────
+EXPOSURE BY ASSET
+───────────────────────────────────────────────────────────────────
+
+  <asset> (<account>)
+    • <package>@<version> — VULNERABLE
+    • <package>@<version> — VULNERABLE
+    • <package>@<version> — Below Range
+
+  <asset> (<account>)
+    • ...
+
+───────────────────────────────────────────────────────────────────
+```
+
+#### "full" — Everything expanded
+
+## Edge Cases
+
+### No packages provided
+```
+⚠ No packages to check. Provide a package list:
+
+  /orca-supply-chain-exposure <name1> <name2> ...
+  /orca-supply-chain-exposure <name>@<version>
+
+Or paste a bullet list from your advisory.
+```
+
+### All packages not found
+```
+✅ None of the <N> packages are present in the monitored environment.
+
+Caveats:
+  • Verify Orca scanner coverage with /orca-account-health
+  • Newly deployed assets may not have been scanned yet
+  • Package may be installed under a different name (alias check recommended)
+```
+
+### Discovery returned > 50 hits for a single package
+```
+⚠ <package> is on more than 50 assets — discovery_search is capped at 50.
+
+Showing top 50 by severity. For the full list:
+  Open the app_url in the discovery_search response.
+```
+
+### User provided versions but Orca returns no version data
+```
+Asset returned a hit for <package> but no version data.
+Manual verification needed in Orca UI → Asset → SBOM.
+```
+
+## MCP Tools Used
+
+### Primary Tools
+
+| Tool | Purpose | Parameter |
+|------|---------|-----------|
+| `discovery_search` | Find assets running a given package | `search_phrase` (NL), `limit` |
+| `get_asset_by_id` | Asset prod/non-prod tag and metadata | `asset_id` (UUID) |
+| `get_asset_related_alerts_summary` | Existing alerts on the affected asset | `asset_id` (UUID) |
+| `get_asset_crown_jewel_info` | Crown jewel status | `group_unique_id` |
+
+### Secondary Tools
+
+| Tool | Purpose | When |
+|------|---------|------|
+| `get_alert` | Pull related CVE alert details | Drill-down into an existing Orca CVE alert for the package |
+| `search_cdr_events` | Recent activity from/to the affected asset | If user asks for activity context |
+
+### Parameter Notes
+
+- `discovery_search` natural-language phrasing matters: both `"assets with package <name>"` and `"assets with vulnerable <name>"` should run — each surfaces different data (inventory vs CVE-tagged).
+- `discovery_search` is **capped at 50 results** per call — the response includes `app_url` for the full set; surface this when truncated.
+- The package-name string must match exactly what Orca indexes; common aliases (e.g. `log4j-core` vs `log4j`) may need two queries.
+
+## Implementation Notes
+
+1. **Parallelize across packages, not just across queries.** For a 10-package advisory, the first batch should be ~20 `discovery_search` calls in one message.
+2. **Version match is the differentiator** — without version comparison this is just a "package found anywhere" check. Always show the installed version and the suspected range side by side.
+3. **"Below Range" is a real status, not a non-finding** — call it out explicitly so the user sees that the check ran and the asset is verified safe.
+4. **Crown jewel + internet-facing flag** turns a generic "vulnerable" hit into a priority-1 incident. Always enrich confirmed exposures with these two fields.
+5. **Link to other skills**: suggest `/orca-impact-analysis` for fix consequences, `/orca-alert-triage` for any related CVE alert, `/orca-account-health` if "not found" results need a coverage sanity-check.
+6. **Optional research escalation**: if connected to the SingleStore observations DB (`mcp__singlestore-observations__execute_sql`), use the `observations_non_inventory` table for cross-tenant package searches. This is a research-mode capability, not a customer-facing flow.


### PR DESCRIPTION
## Summary

Three new reactive-workflow skills that close gaps surfaced by a competitive coverage comparison:

- **`orca-supply-chain-exposure`** — given a list of suspect packages (e.g. a vendor IOC bulletin), find which are actually running in the environment, on which assets, and what's exposed.
- **`orca-cve-blast-radius`** — given a single CVE-ID, enumerate every affected asset across the estate, ranked by exposure (internet-facing, crown jewel, attached IAM).
- **`orca-account-health`** — audit cloud-account coverage: which accounts are connected, last sync time, scan health, missing integrations.

All three follow the existing `SKILL.md` frontmatter + body convention. README "Skills Overview" table updated. No new dependencies, no test framework changes (promptfoo was removed in #11).

## Test plan

- [ ] Trigger `orca-supply-chain-exposure` with a small package list and confirm `discovery_search` fan-out works
- [ ] Trigger `orca-cve-blast-radius` with a known CVE in the demo tenant
- [ ] Trigger `orca-account-health` and confirm `get_integration_configs_data` output renders correctly
- [ ] Verify each skill's trigger phrases resolve to the new skill (not a sibling)